### PR TITLE
Add polkadot helm chart

### DIFF
--- a/DEVSPACE.md
+++ b/DEVSPACE.md
@@ -1,0 +1,17 @@
+# Devspace
+
+It is possible to test the chart on minikube.
+
+First, build the custom images:
+
+```
+devspace build -t dev --skip-push
+```
+
+Create `test_values.yaml` based on the default chart values in charts/polkadot/values.yaml
+
+Then start minikube and run:
+
+```
+helm install test -f test_values.yaml  charts/polkadot --namespace test --create-namespace
+```

--- a/charts/polkadot/.helmignore
+++ b/charts/polkadot/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/polkadot/Chart.yaml
+++ b/charts/polkadot/Chart.yaml
@@ -1,0 +1,23 @@
+apiVersion: v2
+name: polkadot
+description: A Helm chart for Kubernetes
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.1.0
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+appVersion: 1.16.0

--- a/charts/polkadot/README.md
+++ b/charts/polkadot/README.md
@@ -1,0 +1,42 @@
+# Polkadot helm chart
+
+This deploys a polkadot node.
+
+It can:
+
+* sync from a filesystem archive
+* configure its own host key passed as parameter
+* connect to other nodes in different namespaces in a full mesh
+* deploy a network load balancer for p2p ingress in a cloud setup
+
+## How to deploy
+
+See values.yaml comments for detailed explanation of all possible values.
+
+## Example
+
+Deploy val1 chart in namespace `val1`:
+
+```
+polkadot_validator_name: "val1"
+polkadot_archive_url: null
+p2p_ip: 10.0.0.1
+p2p_port: 30333
+local_nodes:
+  nico: 9cd2bad53ae93f45ae19d62f7961679972b9099935ce29d00c2e23efbf2c40bf
+  nico2: 9cd2bad53ae93f45ae19d62f7961679972b9099935ce29d00c2e23efbf2c40be
+```
+
+Deploy val2 chart in namespace `val2`:
+
+```
+polkadot_validator_name: "val2"
+polkadot_archive_url: null
+p2p_ip: 10.0.0.1
+p2p_port: 30334
+local_nodes:
+  nico: 9cd2bad53ae93f45ae19d62f7961679972b9099935ce29d00c2e23efbf2c40bf
+  nico2: 9cd2bad53ae93f45ae19d62f7961679972b9099935ce29d00c2e23efbf2c40be
+```
+
+These 2 validators will extablish p2p peering with each other.

--- a/charts/polkadot/scripts/polkadot-node.sh
+++ b/charts/polkadot/scripts/polkadot-node.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+
+set -e
+set -x
+
+if [ -e /polkadot/k8s_local_node_key ]; then
+    node_key_param="--node-key-file /polkadot/k8s_local_node_key"
+fi
+
+if [ -e /polkadot/k8s_local_peer_cmd ]; then
+    local_peer_param="$(cat /polkadot/k8s_local_peer_cmd)"
+fi
+
+if [ ! -z "$VALIDATOR_NAME" ]; then
+    name_param="--name \"$VALIDATOR_NAME\""
+fi
+
+if [ ! -z "$CHAIN" ]; then
+    chain_param="--chain \"$CHAIN\""
+fi
+
+if [ ! -z "$IN_PEERS" ]; then
+    in_peers_param="--in-peers=${IN_PEERS}"
+fi
+
+if [ ! -z "$OUT_PEERS" ]; then
+    out_peers_param="--out-peers=${OUT_PEERS}"
+fi
+
+if [ ! -z "$TELEMETRY_URL" ]; then
+    telemetry_url_param="--telemetry-url \"$TELEMETRY_URL 0\""
+fi
+
+if [ ! -z "$PUBLIC_MULTIADDR" ]; then
+    public_address_param="--public-addr=${PUBLIC_MULTIADDR}"
+fi
+
+eval /usr/bin/polkadot --validator --wasm-execution Compiled \
+         --unsafe-pruning \
+         --pruning=1000 \
+         --prometheus-external \
+          --execution native \
+         $out_peers_param \
+         $in_peers_param \
+         $node_key_param \
+         $name_param \
+         $telemetry_url_param \
+         $chain_param \
+         $public_address_param \
+         $local_peer_param

--- a/charts/polkadot/templates/configmap.yaml
+++ b/charts/polkadot/templates/configmap.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+data:
+  ARCHIVE_URL: "{{ .Values.polkadot_archive_url }}"
+  TELEMETRY_URL: "{{ .Values.polkadot_telemetry_url }}"
+  VALIDATOR_NAME: "{{ .Values.polkadot_validator_name }}"
+  OUT_PEERS: "{{ .Values.number_of_out_peers }}"
+  IN_PEERS: "{{ .Values.number_of_in_peers }}"
+  CHAIN: "{{ .Values.chain}}"
+  NAMESPACE: "{{ .Release.Namespace }}"
+  PUBLIC_MULTIADDR: "/ip4/{{ .Values.p2p_ip }}/tcp/{{ .Values.p2p_port }}"
+kind: ConfigMap
+metadata:
+  name: polkadot-configmap
+  namespace: {{ .Release.Namespace }}

--- a/charts/polkadot/templates/networkpolicy.yaml
+++ b/charts/polkadot/templates/networkpolicy.yaml
@@ -1,0 +1,40 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: polkadot-private-node-policy
+  namespace: default
+  namespace: {{ .Release.Namespace }}
+spec:
+  podSelector:
+    matchLabels:
+      app: private-node
+  policyTypes:
+  - Ingress
+  - Egress
+  egress:
+  - ports:
+    - port: 53
+      protocol: TCP
+    - port: 53
+      protocol: UDP
+    - port: 443
+      protocol: TCP
+    - port: 30333
+      protocol: TCP
+    - port: 30334
+      protocol: TCP
+    - port: 30100
+      protocol: TCP
+  ingress:
+  - ports:
+    - port: 30333
+      protocol: TCP
+  - ports:
+    - port: 9615
+      protocol: TCP
+    from:
+    - namespaceSelector:
+        matchLabels: {}
+      podSelector:
+        matchLabels:
+          app: prometheus

--- a/charts/polkadot/templates/secrets.yaml
+++ b/charts/polkadot/templates/secrets.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+data:
+{{- range $k, $v := .Values.local_nodes }}
+  {{ $k }}: {{ $v | b64enc }}
+{{- end }}
+kind: Secret
+metadata:
+  name: polkadot-node-keys
+  namespace: {{ .Release.Namespace }}

--- a/charts/polkadot/templates/services.yaml
+++ b/charts/polkadot/templates/services.yaml
@@ -1,0 +1,34 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: private-node
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: private-node
+spec:
+  ports:
+  - port: 9933
+    name: rpc
+  - port: 9615
+    name: metrics
+  selector:
+    app: private-node
+  clusterIP: None
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: private-node-p2p
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: private-node
+spec:
+  ports:
+  - port: {{ .Values.p2p_port }}
+    targetPort: 30333
+    protocol: TCP
+    name: dot-p2p-port
+  loadBalancerIP: {{ .Values.p2p_ip }}
+  selector:
+    app: private-node
+  type: LoadBalancer

--- a/charts/polkadot/templates/statefulset.yaml
+++ b/charts/polkadot/templates/statefulset.yaml
@@ -1,0 +1,85 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: polkadot-node
+  namespace: {{ .Release.Namespace }}
+spec:
+  selector:
+    matchLabels:
+      app: polkadot-node
+  serviceName: polkadot-node
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: polkadot-node
+    spec:
+      securityContext:
+        fsGroup: 1000
+      containers:
+      - name: polkadot-node
+        image: {{ .Values.images.polkadot_node }}
+        command:
+          - /bin/bash
+        args:
+          - "-c"
+          - |
+{{ tpl (.Files.Get "scripts/polkadot-node.sh") . | indent 12 }}
+        ports:
+        - containerPort: 9933
+          name: dot-rpc-port
+        - containerPort: 9615
+          name: metrics
+        - containerPort: 30333
+          name: dot-p2p-port
+        volumeMounts:
+        - name: polkadot-node-pv-claim
+          mountPath: /polkadot
+        envFrom:
+        - configMapRef:
+            name: polkadot-configmap
+        resources:
+          limits:
+            cpu: 0
+        imagePullPolicy: IfNotPresent
+      initContainers:
+      - name: polkadot-node-key-configurator
+        image: {{ .Values.polkadot_k8s_images.polkadot_node_key_configurator }}
+        volumeMounts:
+        - name: polkadot-node-pv-claim
+          mountPath: /polkadot
+        - name: polkadot-node-keys
+          mountPath: /polkadot-node-keys
+        envFrom:
+        - configMapRef:
+            name: polkadot-configmap
+        imagePullPolicy: IfNotPresent
+      - name: polkadot-archive-downloader
+        image: {{ .Values.polkadot_k8s_images.polkadot_archive_downloader }}
+        volumeMounts:
+        - name: polkadot-node-pv-claim
+          mountPath: /polkadot
+        env:
+        - name: CHAIN
+          valueFrom:
+            configMapKeyRef:
+              name: polkadot-configmap
+              key: CHAIN
+        - name: ARCHIVE_URL
+          valueFrom:
+            configMapKeyRef:
+              name: polkadot-configmap
+              key: ARCHIVE_URL
+        imagePullPolicy: IfNotPresent
+      volumes:
+      - name: polkadot-node-keys
+        secret:
+          secretName: polkadot-node-keys
+  volumeClaimTemplates:
+  - metadata:
+      name: polkadot-node-pv-claim
+    spec:
+      accessModes: [ "ReadWriteOnce" ]
+      resources:
+        requests:
+          storage: 20Gi

--- a/charts/polkadot/values.yaml
+++ b/charts/polkadot/values.yaml
@@ -1,0 +1,28 @@
+# Images not part of the tezos-k8s repo go here
+images:
+  polkadot_node: "paritytech/polkadot:latest"
+# Images that are part of the polkadot-k8s repo go here with 'dev' tag
+polkadot_k8s_images:
+  polkadot_archive_downloader: polkadot_archive_downloader:dev
+  polkadot_node_key_configurator: polkadot_node_key_configurator:dev
+
+polkadot_archive_url: https://ksm-rocksdb.polkashots.io/snapshot
+
+polkadot_telemetry_url: null
+
+polkadot_validator_name: polkadot_k8s_pulumi
+
+number_of_out_peers: 10
+
+number_of_in_peers: 10
+
+chain: polkadot
+
+# list of peers to always connect to. could be polkadot nodes in different namespaces
+# should be a list of key-value pairs with the key as namespace name and the value as private network key
+local_nodes: {}
+
+# if provided, this will be passed as the public ip/port combination of the node
+# If you have an ingress network load balancer ip sending p2p traffic to the node, set this to its address/port
+p2p_ip: null
+p2p_port: null

--- a/devspace.yaml
+++ b/devspace.yaml
@@ -1,0 +1,24 @@
+version: v1beta9
+deployments:
+  - name: chain
+    helm:
+      chart:
+        name: ./charts/polkadot
+      valuesFiles:
+        - ./${CHAIN_NAME}_values.yaml
+
+images:
+  polkadot_node_key_configurator:
+    image: polkadot_node_key_configurator
+    dockerfile: ./polkadot-node-key-configurator/Dockerfile
+    context: ./polkadot-node-key-configurator
+  polkadot_archive_downloader:
+    image: polkadot_archive_downloader
+    dockerfile: ./polkadot-archive-downloader/Dockerfile
+    context: ./polkadot-archive-downloader
+
+vars:
+  - name: CHAIN_NAME
+    question: Name of the chain as passed to generate-constants
+    default: "devspace"
+    source: env

--- a/polkadot-archive-downloader/Dockerfile
+++ b/polkadot-archive-downloader/Dockerfile
@@ -1,0 +1,5 @@
+FROM alpine
+RUN apk add curl p7zip bash
+COPY entrypoint.sh /
+ENTRYPOINT ["/entrypoint.sh"]
+CMD []

--- a/polkadot-archive-downloader/entrypoint.sh
+++ b/polkadot-archive-downloader/entrypoint.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+set -e
+
+if [ "${CHAIN}" == "polkadot" ]; then
+    chain_dir=polkadot
+else
+    chain_dir=ksmcc3
+fi
+
+if [ -d /polkadot/.local/share/polkadot/chains/${chain_dir}/db/ ]; then
+    echo "Blockchain database already exists, no need to import, exiting"
+    exit 0
+elif [ -z "$ARCHIVE_URL" ]; then
+    echo "No archive download url specified, exiting"
+    exit 0
+else
+    echo "Did not find pre-existing data, importing blockchain"
+    mkdir -p /polkadot/.local/share/polkadot/chains/${chain_dir}/
+    echo "Will download $ARCHIVE_URL"
+    curl -L $ARCHIVE_URL -o /polkadot/polkadot_archive.7z
+    7z x /polkadot/polkadot_archive.7z -o/polkadot/.local/share/polkadot/chains/${chain_dir}
+    rm -v /polkadot/polkadot_archive.7z
+    chmod -R 777 /polkadot/.local/
+    chown -R 1000:1000 /polkadot/.local/
+    find /polkadot/.local/share/
+fi

--- a/polkadot-node-key-configurator/Dockerfile
+++ b/polkadot-node-key-configurator/Dockerfile
@@ -1,0 +1,12 @@
+FROM parity/subkey:2.0.0
+USER root
+# install tools and dependencies
+RUN apt-get update --allow-insecure-repositories && \
+	DEBIAN_FRONTEND=noninteractive apt-get install -y \
+		xxd && \
+	apt-get autoremove -y && \
+	apt-get clean && \
+	find /var/lib/apt/lists/ -type f -not -name lock -delete;
+COPY entrypoint.sh /
+ENTRYPOINT ["/entrypoint.sh"]
+CMD []

--- a/polkadot-node-key-configurator/entrypoint.sh
+++ b/polkadot-node-key-configurator/entrypoint.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+set -e
+set -x
+
+rm -vf /polkadot/k8s_local_node_key
+rm -rvf /polkadot/k8s_node_ids/
+mkdir -p /polkadot/k8s_node_ids
+
+# write private key for this node only and protect it
+if [ -f /polkadot-node-keys/${NAMESPACE} ]; then
+    cat /polkadot-node-keys/${NAMESPACE} | xxd -r -p > /polkadot/k8s_local_node_key
+    # move owner to polkadot
+    chown 1000 /polkadot/k8s_local_node_key
+    chmod 400 /polkadot/k8s_local_node_key
+fi
+
+
+for node in $(ls /polkadot-node-keys)
+do
+    # do not peer with myself
+    if [ "${node}" != "${NAMESPACE}" ]
+    then
+        if [ ! -f /polkadot/k8s_local_peer_cmd ]; then
+            # write public keys for all peers in an env file, to be sourced by polkadot startup script
+            echo "--reserved-nodes " > /polkadot/k8s_local_peer_cmd
+        fi
+        echo "/dns4/${CHAIN}-node-0.${CHAIN}-node.${node}/tcp/30333/p2p/$(subkey inspect-node-key --file /polkadot-node-keys/$node) " >> /polkadot/k8s_local_peer_cmd
+    fi
+done


### PR DESCRIPTION
This is the chart I was working on a few weeks ago. I then added more
functionality to the polkadot-k8s repo. Today I ported the most recent
changes to here. I also added a README to the chart.

The new things are (1) ability to pass a private network key and (2)
ability to pass the public ip/port combination.

It's possible to deploy locally on minikube and devspace for testing.
DEVSPACE.md has details.

The next step is to create a pulumi component resource that installs
this chart on a cluster.